### PR TITLE
chore: bump version to 0.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dature"
-version = "0.11.0"
+version = "0.12.0"
 description = "Type-safe configuration loader for Python dataclasses with support for YAML, JSON, TOML, INI, ENV and environment variables"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Automated minor version bump: → **0.12.0**
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/niccolum/dature/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
